### PR TITLE
perf: 修复各模块N+1查询问题

### DIFF
--- a/club/core.py
+++ b/club/core.py
@@ -2,6 +2,7 @@ from .models import *
 from django.http import JsonResponse
 from django.views.decorators.http import require_POST
 from django.views.decorators.csrf import csrf_exempt
+from django.db.models import Count
 from .models import UserFavorite, EventClassInformation, StudentClubData
 import json
 
@@ -37,29 +38,47 @@ def fit_constraints(x, A):
 
 def get_selection_data(selection_object, user, is_started, ignore_forbid=False):
     res = {}
-    type_set = EventClassType.objects.filter(event_id=selection_object)
-    class_set = EventClassInformation.objects.filter(event_id=selection_object)
+    # Materialise the type set once so we don't hit the DB multiple times.
+    type_list = list(EventClassType.objects.filter(event_id=selection_object))
+    # Pull the related class_type together with each class to avoid a query per row.
+    class_set = EventClassInformation.objects.filter(
+        event_id=selection_object).select_related('class_type')
     cstt_set = EventClassTypeConstraints.objects.filter(
         event_id=selection_object)
-    cstt_list = [(i.type_id1.pk, i.coef_1, i.type_id2.pk, i.coef_2, i.C)
+    # Use the *_id attributes so we don't trigger a query per constraint row.
+    cstt_list = [(i.type_id1_id, i.coef_1, i.type_id2_id, i.coef_2, i.C)
                  for i in cstt_set]
     user_num = {}
 
-    for i in type_set:
+    for i in type_list:
         user_num[i.pk] = 0
 
-    if type_set.count() <= 1:
+    if len(type_list) <= 1:
         res['display_type'] = False
     else:
         res['display_type'] = True
-        res['types'] = {}
-        for i in type_set:
-            res['types'][i.pk] = i.type_name
+        res['types'] = {i.pk: i.type_name for i in type_list}
 
     res['data'] = []
-    
+
     favorite_ids = set(
         UserFavorite.objects.filter(user=user).values_list("event_class_id", flat=True)
+    )
+
+    # Enrolled count per class for the whole event in a single grouped query.
+    enrolled_counts = dict(
+        StudentSelectionInformation.objects
+        .filter(info_id__event_id=selection_object)
+        .values('info_id')
+        .annotate(cnt=Count('id'))
+        .values_list('info_id', 'cnt')
+    )
+
+    # This user's selections for the whole event in a single query.
+    user_selection_locked = dict(
+        StudentSelectionInformation.objects
+        .filter(info_id__event_id=selection_object, user_id=user)
+        .values_list('info_id', 'locked')
     )
 
     for c in class_set:
@@ -74,16 +93,12 @@ def get_selection_data(selection_object, user, is_started, ignore_forbid=False):
         c_res['desc'] = c.desc
         c_res['name'] = c.name
         c_res['mnum'] = c.max_num
-        c_res['cnum'] = StudentSelectionInformation.objects.filter(
-            info_id=c).count()
+        c_res['cnum'] = enrolled_counts.get(c.pk, 0)
         c_res['rnum'] = max(c.max_num - c_res['cnum'], 0)
-        
+
         c_res['is_favorite'] = (c.pk in favorite_ids)
 
-        rel = StudentSelectionInformation.objects.filter(
-            info_id=c, user_id=user)
-
-        if rel.count() == 0:
+        if c.pk not in user_selection_locked:
 
             if (c.forbid_chs and (not ignore_forbid)):
                 c_res['status'] = 2
@@ -95,10 +110,9 @@ def get_selection_data(selection_object, user, is_started, ignore_forbid=False):
                 c_res['status'] = 0
 
         else:
-            info = rel[0]
             user_num[c_type.pk] += 1
 
-            if info.locked:
+            if user_selection_locked[c.pk]:
                 c_res['status'] = 5
 
             else:
@@ -262,7 +276,10 @@ def convert_selection_data_to_html(data):
 
 def get_selection_list(rec):
 
-    sel_list = StudentSelectionInformation.objects.filter(info_id=rec)
+    # Fetch the related user and prefetch their groups so the loop below does
+    # not issue a query per student (and per student's group set).
+    sel_list = StudentSelectionInformation.objects.filter(
+        info_id=rec).select_related('user_id').prefetch_related('user_id__groups')
 
     res = {'locked': [], 'other': []}
 
@@ -271,8 +288,6 @@ def get_selection_list(rec):
                     'g': ','.join([g.name for g in s.user_id.groups.all()])}
         if s.locked:
             res['locked'].append(cur_data)
-            res['other'].append(cur_data)
-        else:
-            res['other'].append(cur_data)
+        res['other'].append(cur_data)
 
     return res

--- a/club/view/selection.py
+++ b/club/view/selection.py
@@ -112,7 +112,7 @@ def selection_home_view(request):
 
     time_now = timezone.now()
 
-    for s in SelectionEvent.objects.all():
+    for s in SelectionEvent.objects.prefetch_related('student_group').all():
 
         if s.end_time < time_now:
 
@@ -120,16 +120,18 @@ def selection_home_view(request):
 
         student_string = ''
 
-        student_count = s.student_group.count()
+        # Use the prefetched list so we don't run a query per event.
+        student_groups = list(s.student_group.all())
+        student_count = len(student_groups)
 
         if student_count == 0:
             student_string = '无'
 
         elif student_count == 1:
-            student_string = s.student_group.all()[0].name
+            student_string = student_groups[0].name
 
         else:
-            student_string = s.student_group.all()[0].name + '等'
+            student_string = student_groups[0].name + '等'
 
         if s.start_time <= time_now:
 

--- a/club/view/user_ui.py
+++ b/club/view/user_ui.py
@@ -97,7 +97,7 @@ def event_manage_view(request):
         raise Http404
 
     user_groups      = [t.name for t in request.user.groups.all()]
-    _s               = SelectionEvent.objects.all()
+    _s               = SelectionEvent.objects.prefetch_related('teachers_group').all()
     table_content    = "<tr><td><a href='%s?id=%d'>%s</a></td><td>%s</td><td>%s</td></tr>"
     modify_event_url = "/modify_event"
     cs               = []
@@ -315,7 +315,7 @@ def modify_event_view(request):
                             cap = True
                         break
                 if (not cap):
-                    cc_l = [cc.info_id.name for cc in StudentSelectionInformation.objects.filter(user_id=user) if cc.info_id.event_id==_]
+                    cc_l = [cc.info_id.name for cc in StudentSelectionInformation.objects.filter(user_id=user).select_related('info_id') if cc.info_id.event_id_id == _.pk]
                     return JsonResponse({'code':0,'message':'该用户课程数已达上限或您设置的上限人数不够大，该用户已报名%s' % (','.join(cc_l))})
 
                 ssi = StudentSelectionInformation(info_id=rec,user_id=user,locked=True)

--- a/league/forms.py
+++ b/league/forms.py
@@ -53,11 +53,11 @@ class ModifyLeagueForm(forms.Form):
 
     time = forms.DateTimeField(required=True, label='开始时间（格式：YYYY-mm-dd HH:mm:ss）')
 
-    a_class = forms.ChoiceField(required=True, label='队伍A',
-                                choices=ClassTeamData.objects.values_list("id", "name"))
+    # Choices are populated per-instance in __init__ (see ``query_set``); we
+    # must not query the DB at import time (it also breaks on a fresh DB).
+    a_class = forms.ChoiceField(required=True, label='队伍A', choices=[])
 
-    b_class = forms.ChoiceField(required=True, label='队伍B',
-                                choices=ClassTeamData.objects.values_list("id", "name"))
+    b_class = forms.ChoiceField(required=True, label='队伍B', choices=[])
 
     a_score = forms.IntegerField(required=True, label='队伍A分数')
 

--- a/league/views.py
+++ b/league/views.py
@@ -15,7 +15,7 @@ import datetime
 # Create your views here.
 
 def index(request):
-    matches = MatchData.objects.all()
+    matches = MatchData.objects.select_related('a_class', 'b_class').all()
     form = []
 
     for m in matches:
@@ -35,7 +35,7 @@ def index(request):
 
   
 def detail(request):
-    matches = MatchData.objects.all()
+    matches = MatchData.objects.select_related('a_class', 'b_class').all()
     form, form_past = [], []
 
     for m in matches:
@@ -58,7 +58,7 @@ def detail(request):
 def sports_detail(request):
     matchID = request.GET.get('id', None)
 
-    match = MatchData.objects.get(pk=matchID)
+    match = MatchData.objects.select_related('a_class', 'b_class').get(pk=matchID)
     i = match.toDict()
     time = (i['time'] + datetime.timedelta(hours=8)).strftime("%Y-%m-%d %H:%M")
     i['time'] = time
@@ -94,7 +94,7 @@ def league_manage(request):
             print(e)
             return JsonResponse({'code': 0, 'message': '数据非法或发生了错误'})
 
-    _s = MatchData.objects.all()
+    _s = MatchData.objects.select_related('a_class', 'b_class').all()
     table_content = "<tr><td><a href='%s?id=%d'>%s</a></td><td>%s</td><td>%s</td><td>%s</td><td>%d</td><td>%d</td><td>%s</td></tr>"
     cs = []
     for _ in _s:

--- a/record/core.py
+++ b/record/core.py
@@ -16,6 +16,8 @@ def export_record_holder(request):
     if (not (request.user.is_superuser or request.user.is_staff)):
         raise Http404
     record_holders = RecordHolderData.objects.all().values_list('name', 's_class', 'record', 'related_record', 'visibility', 'time')
+    # Load all record names once instead of querying twice per holder row.
+    record_names = dict(RecordData.objects.values_list('id', 'name'))
     response = HttpResponse(content_type='text/csv')
     response.charset = 'utf-8-sig'
     response['Content-Disposition'] = 'attachment; filename="record_holder_data_' + datetime.now().strftime("%d/%m/%Y %H:%M:%S") + '.csv"'
@@ -26,8 +28,7 @@ def export_record_holder(request):
         r.append(row[0])
         r.append(row[1])
         r.append(row[2])
-        r.append(RecordData.objects.get(pk=row[3]).name)
-        print(RecordData.objects.get(pk=row[3]).name)
+        r.append(record_names.get(row[3]))
         r.append(row[4])
         r.append(row[5])
         writer.writerow(r)

--- a/record/forms.py
+++ b/record/forms.py
@@ -53,8 +53,9 @@ class ModifyRecordHolderForm(forms.Form):
 
     s_class = forms.CharField(label='班级', required=True, min_length=1, max_length=200)
 
-    related_record = forms.ChoiceField(required=True, label='相关纪录',
-                            choices=RecordData.objects.values_list("id", "name"))
+    # Choices are populated per-instance in __init__ (see ``query_set``); we
+    # must not query the DB at import time (it also breaks on a fresh DB).
+    related_record = forms.ChoiceField(required=True, label='相关纪录', choices=[])
 
     record = forms.CharField(label='纪录成绩', required=True, min_length=1, max_length=200)
 

--- a/record/views.py
+++ b/record/views.py
@@ -16,7 +16,7 @@ def index(request):
 
 def sport_record(request):
     records = RecordData.objects.all()
-    recordHolders = RecordHolderData.objects.all()
+    recordHolders = RecordHolderData.objects.select_related('related_record').all()
     form = []
     form_h = []
 
@@ -48,7 +48,7 @@ def sport_record(request):
 
 def fun_record(request):
     records = RecordData.objects.all()
-    recordHolders = RecordHolderData.objects.all()
+    recordHolders = RecordHolderData.objects.select_related('related_record').all()
     form = []
     form_h = []
 
@@ -108,7 +108,7 @@ def record_holder_manage(request):
     if (not (request.user.is_superuser or request.user.is_staff)):
         raise Http404
 
-    _s = RecordHolderData.objects.all()
+    _s = RecordHolderData.objects.select_related('related_record').all()
     table_content = "<tr><td><a href='%s?id=%d'>%s</a></td><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>"
     cs = []
     for _ in _s:

--- a/verification/views.py
+++ b/verification/views.py
@@ -13,11 +13,11 @@ def verify_student(request: HttpRequest):
 
     try:
         with connection.cursor() as cursor:
-            
-            query = "SELECT student_real_name, student_id FROM club_studentclubdata WHERE username=\"%s\";"
-            
-            cursor.execute(query%mail)
-            
+
+            query = "SELECT student_real_name, student_id FROM club_studentclubdata WHERE username=%s;"
+
+            cursor.execute(query, [mail])
+
             result = cursor.fetchone()
 
             if result:

--- a/volunteer/core.py
+++ b/volunteer/core.py
@@ -16,6 +16,16 @@ def export(request):
     if (not (request.user.is_superuser or request.user.is_staff)):
         raise Http404
     students = StudentClubData.objects.all()
+    # Pre-load every "checked" flag in a single query instead of one per student.
+    checked_user_ids = set(
+        StudentDataChecker.objects.filter(data_checked=True)
+        .values_list('user_id', flat=True)
+    )
+    # Group all score records (with their event) by user in a single query so
+    # the per-student loop below does no additional database access.
+    scores_by_user = {}
+    for sc in StudentScoreData.objects.select_related('score_event_id'):
+        scores_by_user.setdefault(sc.user_id_id, []).append(sc)
     map = {}
     cur = 0
     listOfGrades = []
@@ -26,13 +36,9 @@ def export(request):
         listStudent = []
         listStudent.append(i.student_id)
         listStudent.append(i.student_real_name)
-        check_name = "未确认"
-        check_item = StudentDataChecker.objects.filter(user_id=i)
-        if len(check_item) != 0:
-            if check_item[0].data_checked:
-                check_name = "已确认"
+        check_name = "已确认" if i.pk in checked_user_ids else "未确认"
         listStudent.append(check_name)
-        events = StudentScoreData.objects.filter(user_id=i).all()
+        events = scores_by_user.get(i.pk, [])
         for j in events:
             eventDetail = j.score_event_id
             listStudent.append(eventDetail.name)

--- a/volunteer/views.py
+++ b/volunteer/views.py
@@ -33,7 +33,8 @@ def generate_row(name, score, date):
 
 @login_required()
 def index(request):
-    _ = StudentScoreData.objects.filter(user_id=request.user.pk)
+    _ = StudentScoreData.objects.filter(
+        user_id=request.user.pk).select_related('score_event_id')
     content = ''
     ck_table = StudentDataChecker.objects.filter(user_id=request.user.pk)
     data_checked = False
@@ -91,15 +92,16 @@ def score_manage(request):
     user_data = ''
 
     if student_id != None:
-        _s = StudentScoreData.objects.filter(user_id=student_id)
+        _s = StudentScoreData.objects.filter(
+            user_id=student_id).select_related('score_event_id')
         ss = StudentClubData.objects.get(pk=student_id)
         user_data = ' - %s %s' % (ss.student_id, ss.student_real_name)
         table_content = "<tr><td><a href='%s?id=%d'>%s</a></td><td>%s</td><td>%s</td></tr>"
         cs = []
         for _ in _s:
-            li = ScoreEventData.objects.filter(pk=_.score_event_id.pk)
+            ev = _.score_event_id
             cs.append(table_content %
-                      (modify_score_url, _.pk, li[0].name, li[0].point, _.date_of_addition))
+                      (modify_score_url, _.pk, ev.name, ev.point, _.date_of_addition))
         cs.sort(key=lambda x: x[0])
 
         for i in cs:

--- a/youth_league/core.py
+++ b/youth_league/core.py
@@ -123,14 +123,15 @@ def export_course_score_data(request):
     if (not (request.user.is_superuser or request.user.is_staff)):
         raise Http404
     course_score_export = CourseAssignmentScore.objects.all().values_list('course_id', 'stu_id', 'score')
+    # Map internal ids to student numbers once instead of one query per row.
+    stu_no_map = dict(StudentClubData.objects.values_list('id', 'student_id'))
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename="course_score_' + datetime.now().strftime("%d-%m-%Y %H:%M:%S") + '.csv"'
     writer = csv.writer(response)
     writer.writerow(['course_id', 'stu_id', 'score'])
     for row in course_score_export:
         modified = list(row)
-        stu_no = StudentClubData.objects.filter(id=row[1]).values('student_id')[0]['student_id']
-        modified[1] = stu_no
+        modified[1] = stu_no_map.get(row[1])
         writer.writerow(modified)
     return response
 
@@ -305,14 +306,15 @@ def export_test_score_data(request):
     if (not (request.user.is_superuser or request.user.is_staff)):
         raise Http404
     test_score_export = TestScore.objects.all().values_list('test_id', 'stu_id', 'score')
+    # Map internal ids to student numbers once instead of one query per row.
+    stu_no_map = dict(StudentClubData.objects.values_list('id', 'student_id'))
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename="test_score_' + datetime.now().strftime("%d/%m/%Y %H:%M:%S") + '.csv"'
     writer = csv.writer(response)
     writer.writerow(['test_id', 'stu_id', 'score'])
     for row in test_score_export:
         modified = list(row)
-        stu_no = StudentClubData.objects.filter(id=row[1]).values('student_id')[0]['student_id']
-        modified[1] = stu_no
+        modified[1] = stu_no_map.get(row[1])
         writer.writerow(modified)
     return response
 

--- a/youth_league/views.py
+++ b/youth_league/views.py
@@ -89,7 +89,7 @@ def index(request):
     course_titles = dict(CourseData.objects.values_list('id', 'title'))
     test_titles = dict(TestData.objects.values_list('id', 'title'))
     for i in appeal_data_course:
-        course_title = course_titles.get(i['course_id'])
+        course_title = course_titles.get(i['course_id'], '未知课程')
         if len(i['response']) != 0:
             appeal_content += generate_row_notice(i['id'], course_title, i['content'], i['response'], str(i['update_time'])[0:16])
         else:

--- a/youth_league/views.py
+++ b/youth_league/views.py
@@ -173,8 +173,8 @@ def test_inquiry(request):
         test_stu_score = stu_score_map.get(i.pk, '--')
 
         stats = test_stats.get(i.pk, {})
-        test_avg = stats.get('avg')
-        test_max = stats.get('max')
+        test_avg = stats.get('avg') if stats.get('avg') is not None else '--'
+        test_max = stats.get('max') if stats.get('max') is not None else '--'
         content_type = 'test'
         content += generate_row(content_type, i.pk, test_title, test_date, test_stu_score, test_avg, test_max, content_type, i.pk, i.pk)
 

--- a/youth_league/views.py
+++ b/youth_league/views.py
@@ -85,8 +85,11 @@ def generate_row_notice(id, title, content, response, time):
 def index(request):
     appeal_data_course = AppealData.objects.filter(stu_id=request.user.pk).values('id', 'content', 'response', 'update_time', 'creation_time', 'course_id').order_by('update_time')
     appeal_content = ''
+    # Load lookup tables once instead of querying per appeal row.
+    course_titles = dict(CourseData.objects.values_list('id', 'title'))
+    test_titles = dict(TestData.objects.values_list('id', 'title'))
     for i in appeal_data_course:
-        course_title = CourseData.objects.filter(id=i['course_id']).values('title')[0]['title']
+        course_title = course_titles.get(i['course_id'])
         if len(i['response']) != 0:
             appeal_content += generate_row_notice(i['id'], course_title, i['content'], i['response'], str(i['update_time'])[0:16])
         else:
@@ -94,7 +97,7 @@ def index(request):
 
     appeal_data_test = AppealDataTest.objects.filter(stu_id=request.user.pk).values('id', 'content', 'response', 'update_time', 'creation_time', 'test_id').order_by('update_time')
     for i in appeal_data_test:
-        test_title = TestData.objects.filter(id=i['test_id']).values('title')[0]['title']
+        test_title = test_titles.get(i['test_id'])
         if len(i['response']) != 0:
             appeal_content += generate_row_notice(i['id'], test_title, i['content'], i['response'], str(i['update_time'])[0:16])
         else:
@@ -105,27 +108,29 @@ def index(request):
 @login_required()
 def homework_inquiry(request):
     student_id = request.user.pk
-    stu_score = CourseAssignmentScore.objects.filter(stu_id=student_id).values('score', 'course_id').order_by('course_id')
-    stu_score_available = []
-    stu_score_numc = 0
-    for i in stu_score:
-        stu_score_available.append(stu_score[stu_score_numc]['course_id'])
-        stu_score_numc += 1
+    # This student's scores keyed by course, fetched once.
+    stu_score_map = dict(
+        CourseAssignmentScore.objects.filter(stu_id=student_id)
+        .values_list('course_id', 'score')
+    )
+    # Average and maximum per course computed in a single grouped query
+    # instead of two aggregate queries per course.
+    course_stats = {
+        s['course_id']: s
+        for s in CourseAssignmentScore.objects.values('course_id').annotate(
+            avg=Avg('score'), max=Max('score'))
+    }
 
     course_list = CourseData.objects.all()
     content=''
-    course_id_available_pointer=0
     for i in course_list:
         course_title = i.title
         course_date = i.date
-        if i.pk in stu_score_available:
-            course_stu_score = stu_score[course_id_available_pointer]['score']
-            course_id_available_pointer += 1
-        else:
-            course_stu_score = '--'
+        course_stu_score = stu_score_map.get(i.pk, '--')
 
-        course_avg = CourseAssignmentScore.objects.filter(course_id=i.pk).aggregate(Avg('score'))['score__avg']
-        course_max = CourseAssignmentScore.objects.filter(course_id=i.pk).aggregate(Max('score'))['score__max']
+        stats = course_stats.get(i.pk, {})
+        course_avg = stats.get('avg')
+        course_max = stats.get('max')
         content_type = 'course'
         content += generate_row(content_type, i.pk, course_title, course_date, course_stu_score, course_avg, course_max, content_type, i.pk, i.pk)
 
@@ -147,27 +152,29 @@ def homework_inquiry(request):
 @login_required()
 def test_inquiry(request):
     student_id = request.user.pk
-    stu_score = TestScore.objects.filter(stu_id=student_id).values('score', 'test_id').order_by('test_id')
-    stu_score_available = []
-    stu_score_numc = 0
-    for i in stu_score:
-        stu_score_available.append(stu_score[stu_score_numc]['test_id'])
-        stu_score_numc += 1
+    # This student's scores keyed by test, fetched once.
+    stu_score_map = dict(
+        TestScore.objects.filter(stu_id=student_id)
+        .values_list('test_id', 'score')
+    )
+    # Average and maximum per test computed in a single grouped query
+    # instead of two aggregate queries per test.
+    test_stats = {
+        s['test_id']: s
+        for s in TestScore.objects.values('test_id').annotate(
+            avg=Avg('score'), max=Max('score'))
+    }
 
     test_list = TestData.objects.all()
     content=''
-    test_id_available_pointer=0
     for i in test_list:
         test_title = i.title
         test_date = i.date
-        if i.pk in stu_score_available:
-            test_stu_score = stu_score[test_id_available_pointer]['score']
-            test_id_available_pointer += 1
-        else:
-            test_stu_score = '--'
+        test_stu_score = stu_score_map.get(i.pk, '--')
 
-        test_avg = TestScore.objects.filter(test_id=i.pk).aggregate(Avg('score'))['score__avg']
-        test_max = TestScore.objects.filter(test_id=i.pk).aggregate(Max('score'))['score__max']
+        stats = test_stats.get(i.pk, {})
+        test_avg = stats.get('avg')
+        test_max = stats.get('max')
         content_type = 'test'
         content += generate_row(content_type, i.pk, test_title, test_date, test_stu_score, test_avg, test_max, content_type, i.pk, i.pk)
 
@@ -282,18 +289,21 @@ def appeal_respond(request):
     appeal_data_handled = AppealData.objects.filter(state=True).values('id', 'stu_id', 'course_id', 'content', 'creation_time', 'response')
     content_not_handled = ''
     content_handled = ''
+    # Preload lookup tables once instead of querying per appeal row.
+    stu_no_map = dict(StudentClubData.objects.values_list('id', 'student_id'))
+    course_titles = dict(CourseData.objects.values_list('id', 'title'))
     for row in appeal_data_not_handled:
         appeal_id = row['id']
-        stu_no = StudentClubData.objects.filter(id=row['stu_id']).values('student_id')[0]['student_id']
-        course_title = CourseData.objects.filter(id=row['course_id']).values('title')[0]['title']
+        stu_no = stu_no_map.get(row['stu_id'])
+        course_title = course_titles.get(row['course_id'])
         content = row['content']
         creation_time = str(row['creation_time'])[0:16]
         content_not_handled += generate_row_appeal_not_handled(appeal_id, stu_no, course_title, content, creation_time)
 
     for row in appeal_data_handled:
         appeal_id = row['id']
-        stu_no = StudentClubData.objects.filter(id=row['stu_id']).values('student_id')[0]['student_id']
-        course_title = CourseData.objects.filter(id=row['course_id']).values('title')[0]['title']
+        stu_no = stu_no_map.get(row['stu_id'])
+        course_title = course_titles.get(row['course_id'])
         content = row['content']
         creation_time = str(row['creation_time'])[0:16]
         response = row['response']
@@ -326,18 +336,21 @@ def appeal_test_respond(request):
     appeal_data_handled = AppealDataTest.objects.filter(state=True).values('id', 'stu_id', 'test_id', 'content', 'creation_time', 'response')
     content_not_handled = ''
     content_handled = ''
+    # Preload lookup tables once instead of querying per appeal row.
+    stu_no_map = dict(StudentClubData.objects.values_list('id', 'student_id'))
+    test_titles = dict(TestData.objects.values_list('id', 'title'))
     for row in appeal_data_not_handled:
         appeal_id = row['id']
-        stu_no = StudentClubData.objects.filter(id=row['stu_id']).values('student_id')[0]['student_id']
-        test_title = TestData.objects.filter(id=row['test_id']).values('title')[0]['title']
+        stu_no = stu_no_map.get(row['stu_id'])
+        test_title = test_titles.get(row['test_id'])
         content = row['content']
         creation_time = str(row['creation_time'])[0:16]
         content_not_handled += generate_row_appeal_not_handled(appeal_id, stu_no, test_title, content, creation_time)
 
     for row in appeal_data_handled:
         appeal_id = row['id']
-        stu_no = StudentClubData.objects.filter(id=row['stu_id']).values('student_id')[0]['student_id']
-        test_title = TestData.objects.filter(id=row['test_id']).values('title')[0]['title']
+        stu_no = stu_no_map.get(row['stu_id'])
+        test_title = test_titles.get(row['test_id'])
         content = row['content']
         creation_time = str(row['creation_time'])[0:16]
         response = row['response']


### PR DESCRIPTION
- club 选课: get_selection_data/get_selection_list 用 select_related/prefetch_related + 分组聚合，查询数恒定
- league/record: toDict 与列表页用 select_related 预取外键
- volunteer/youth_league: 导出与查询用字典预取 + 分组聚合替代逐行查询
- 修复 league/record forms 在导入时执行 DB 查询（空库下会崩溃）
- verification: 改用参数化查询修复 SQL 注入